### PR TITLE
Unsubscribe from event handler on destroy

### DIFF
--- a/src/select2/select2.component.ts
+++ b/src/select2/select2.component.ts
@@ -535,4 +535,8 @@ export class Select2Component {
 			});
         }
     }
+        
+    ngOnDestroy() {
+        this.element.off("select2:select");
+    }
 }


### PR DESCRIPTION
Detach event handler to avoid memory leaks.