### PR TITLE
Adding support to unselect function

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,13 +15,13 @@ yarn.lock
 yarn-error.log
 .npmignore
 
-#TS files
-**/*.ts
-*.ts
-!**/*.d.ts
-!*.d.ts
-tsconfig.json
-tsconfig-aot.json
+# TS files
+# **/*.ts
+# *.ts
+# !**/*.d.ts
+# !*.d.ts
+# tsconfig.json
+# tsconfig-aot.json
 
 #System Files
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "@types/select2": "^4.0.30"
   },
   "peerDependencies": {
-    "@angular/common": "^2.2.0",
-    "@angular/compiler": "^2.2.0",
-    "@angular/core": "^2.2.0"
+    "@angular/common": "^2.2.4",
+    "@angular/compiler": "^2.2.4",
+    "@angular/core": "^2.2.4"
   },
   "devDependencies": {
     "@angular/common": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng2-select2",
   "version": "1.0.0-beta.7",
   "description": "Angular2 wrapper for select2",
-  "main": "ng2-select2.js",
+  "main": "ng2-select2.ts",
   "typings": "ng2-select2.d.ts",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-select2",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "description": "Angular2 wrapper for select2",
   "main": "ng2-select2.js",
   "typings": "ng2-select2.d.ts",

--- a/src/select2.component.ts
+++ b/src/select2.component.ts
@@ -96,9 +96,15 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
             this.element.trigger('change.select2');
         }
 
-        this.element.on('select2:select select2:unselect', function () {
+        this.element.on('select2:select', function() {
             that.valueChanged.emit({
                 value: that.element.val()
+            });
+        });
+
+        this.element.on('select2:unselect', function() {
+            that.valueChanged.emit({
+                value: null
             });
         });
     }


### PR DESCRIPTION
I noticed that when enabling the allowClear option and clicking on the clear button, the event that was being called from select2 was not working properly.
The problem is in that part of the code:
`
this.element.on('select2:select select2:unselect', function () {
            that.valueChanged.emit({
                value: that.element.val()
            });
        });
`

The element value was still the old value and not the "cleared" one.
To fix that I am suggesting to implement the unselect part separately:
`this.element.on('select2:select', function() {
            that.valueChanged.emit({
                value: that.element.val()
            });
        });

        this.element.on('select2:unselect', function() {
            that.valueChanged.emit({
                value: null
            });
        });
`