### PR TITLE
cssImport false / pass select2 data in change event

### DIFF
--- a/lib/ng2-select2.component.ts
+++ b/lib/ng2-select2.component.ts
@@ -21,7 +21,7 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
     @Input() value: string | string[];
 
     // enable / disable default style for select2
-    @Input() cssImport: boolean = true;
+    @Input() cssImport: boolean = false;
 
     // width of select2 input
     @Input() width: string;
@@ -65,7 +65,8 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
 
             const newValue: string = this.element.val();
             this.valueChanged.emit({
-                value: newValue
+                value: newValue,
+                data: this.element.select2('data')
             });
         }
 
@@ -75,7 +76,8 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
             this.setElementValue(newValue);
 
             this.valueChanged.emit({
-                value: newValue
+                value: newValue,
+                data: this.element.select2('data')
             });
         }
 
@@ -85,8 +87,6 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
     }
 
     ngAfterViewInit() {
-        let that = this;
-
         this.element = jQuery(this.selector.nativeElement);
         this.initPlugin();
 
@@ -94,9 +94,10 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
             this.setElementValue(this.value);
         }
 
-        this.element.on('select2:select select2:unselect', function () {
-            that.valueChanged.emit({
-                value: that.element.val()
+        this.element.on('select2:select select2:unselect', () => {
+            this.valueChanged.emit({
+                value: this.element.val(),
+                data: this.element.select2('data')
             });
         });
     }


### PR DESCRIPTION
cssImport changes the global context so setting it to true on one component in the app, loads the CSS for all. Disable it by default (I opt for removing it altogether).

Don't use `that` hack, use closures instead to get the desired context of `this`.

Pass the select2 data structure for each `valueChanged` event.