### PR TITLE
Allow descriptive select2 options

### DIFF
--- a/lib/ng2-select2.component.ts
+++ b/lib/ng2-select2.component.ts
@@ -7,7 +7,11 @@ import { Select2OptionData } from './ng2-select2.interface';
 
 @Component({
     selector: 'select2',
-    template: '<select #selector></select>',
+    template: `
+        <select #selector>
+            <ng-content select="option">
+            </ng-content>
+        </select>`,
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/lib/ng2-select2.component.ts
+++ b/lib/ng2-select2.component.ts
@@ -9,7 +9,7 @@ import { Select2OptionData } from './ng2-select2.interface';
     selector: 'select2',
     template: `
         <select #selector>
-            <ng-content select="option">
+            <ng-content select="option, optgroup">
             </ng-content>
         </select>`,
     encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
Apart from passing a structure to `data`, select2 can also process `<option>` tags. This change transcludes those tags from the component markup.