### PR TITLE
Bugfix: Multiselectvalues where not updated

### DIFF
--- a/lib/ng2-select2.component.ts
+++ b/lib/ng2-select2.component.ts
@@ -1,6 +1,6 @@
 import {
     AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy,
-    Output, SimpleChanges, ViewChild, ViewEncapsulation, Renderer, OnInit
+    Output, SimpleChanges, ViewChild, ViewEncapsulation, Renderer, OnInit, DoCheck
 } from '@angular/core';
 
 import { Select2OptionData } from './ng2-select2.interface';
@@ -15,7 +15,7 @@ import { Select2OptionData } from './ng2-select2.interface';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, OnInit {
+export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, OnInit, DoCheck {
     @ViewChild('selector') selector: ElementRef;
 
     // data for select2 drop down
@@ -23,6 +23,7 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
 
     // value for select2
     @Input() value: string | string[];
+    private oldValueLength = 0;
 
     // enable / disable default style for select2
     @Input() cssImport: boolean = false;
@@ -87,6 +88,15 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
 
         if(changes['disabled'] && changes['disabled'].previousValue !== changes['disabled'].currentValue) {
             this.renderer.setElementProperty(this.selector.nativeElement, 'disabled', this.disabled);
+        }
+    }
+
+    ngDoCheck() {
+        if ($.isArray(this.value)) {
+            if (this.oldValueLength !== this.value.length) {
+                this.oldValueLength = this.value.length;
+                this.setElementValue(this.value);
+            }
         }
     }
 


### PR DESCRIPTION
When using this element with the "multiple" option, the value was not updated when it was changed from outside.

This was because "ngOnChanges" only performes a value checking not, a deep value checking. (Source: https://stackoverflow.com/questions/34796901/angular2-change-detection-ngonchanges-not-firing-for-nested-object ).
Beucause with the "multiple" option, "value" is a "string[]", a simple "ngOnChanges" check is not enough enough, it needs to check on "ngDoCheck".

Code:
    ngDoCheck() {
        if ($.isArray(this.value)) {
            if (this.oldValueLength !== this.value.length) {
                this.oldValueLength = this.value.length;
                this.setElementValue(this.value);
            }
        }
    }^


This code only check, if the value is an array and sets the new value in an array. To detect the change, 
    private oldValueLength = 0;
Is added, to keep track of the last lenght. (changes from null to array where already detected.)