### PR TITLE
Fix: null check in ngOnDestroy

### DIFF
--- a/lib/ng2-select2.component.ts
+++ b/lib/ng2-select2.component.ts
@@ -107,7 +107,9 @@ export class Select2Component implements AfterViewInit, OnChanges, OnDestroy, On
     }
 
     ngOnDestroy() {
-        this.element.off("select2:select");
+        if (this.element && this.element.off) {
+            this.element.off("select2:select");
+        }
     }
 
     private async initPlugin() {


### PR DESCRIPTION
This fix check for the element as well as if the **off** function exists.